### PR TITLE
Update install_github instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,8 +132,7 @@ Install:
 ```
 install.packages("devtools")
 library(devtools)
-install_github("Rbunyan", username="joyent")
-install_github("mantaRSDK", username="joyent")
+install_github(c("joyent/Rbunyan", "joyent/mantaRSDK"))
 ```
 
 Test:


### PR DESCRIPTION
Install_github(pkg, username="joyent") works, but triggers a
warning message "Username parameter is deprecated. Please use
joyent/pkg".
- Changed to include username in the repository address.
- Added c() to include both packages.
